### PR TITLE
xstd/xslices: Add Map slice functions

### DIFF
--- a/xstd/README.md
+++ b/xstd/README.md
@@ -1,0 +1,7 @@
+# xstd
+
+xstd is a collection of packages that extend standard-library packages,
+such as the "slices" package, extended under "xslices".
+
+The "x" prefix is used to avoid conflicting the standard-library package
+so both can be imported and used without import aliasing.

--- a/xstd/xslices/doc.go
+++ b/xstd/xslices/doc.go
@@ -1,0 +1,2 @@
+// Package xslices contains functions that extend the functionality of [slices].
+package xslices

--- a/xstd/xslices/go.mod
+++ b/xstd/xslices/go.mod
@@ -1,0 +1,3 @@
+module go.prashantv.com/xstd/xslices
+
+go 1.24

--- a/xstd/xslices/map.go
+++ b/xstd/xslices/map.go
@@ -1,0 +1,58 @@
+package xslices
+
+import (
+	"context"
+	"fmt"
+)
+
+// Map runs the mapping function to map a slice to a new slice.
+func Map[X, Y any](xs []X, fn func(X) Y) []Y {
+	if xs == nil {
+		return nil
+	}
+
+	ys := make([]Y, len(xs))
+	// Iterate by index only, so xs[i] is directly read into the function argument.
+	for i := range xs {
+		ys[i] = fn(xs[i])
+	}
+	return ys
+}
+
+// MapErr runs the mapping function to map a slice to a new slice.
+// The mapping function may return an error which stops and returns the partially mapped slice.
+func MapErr[X, Y any](xs []X, fn func(X) (Y, error)) ([]Y, error) {
+	if xs == nil {
+		return nil, nil
+	}
+
+	ys := make([]Y, len(xs))
+	for i := range xs {
+		var err error
+		ys[i], err = fn(xs[i])
+		if err != nil {
+			return nil, fmt.Errorf("index %d: %w", i, err)
+		}
+	}
+
+	return ys, nil
+}
+
+// MapCtx runs the context-aware mapping function to map a slice to a new slice.
+// The mapping function may return an error which stops and returns the partially mapped slice.
+// MapCtx does not explicitly check for context errors, the mapping function is expected to respect and propagate context errors.
+func MapCtx[X, Y any](ctx context.Context, xs []X, fn func(context.Context, X) (Y, error)) ([]Y, error) {
+	if xs == nil {
+		return nil, nil
+	}
+
+	ys := make([]Y, len(xs))
+	for i := range xs {
+		var err error
+		ys[i], err = fn(ctx, xs[i])
+		if err != nil {
+			return nil, fmt.Errorf("index %d: %w", i, err)
+		}
+	}
+	return ys, nil
+}

--- a/xstd/xslices/map_test.go
+++ b/xstd/xslices/map_test.go
@@ -1,0 +1,220 @@
+package xslices
+
+import (
+	"context"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestMap(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []int
+		want []string
+	}{
+		{
+			name: "nil",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "empty slice",
+			in:   []int{},
+			want: []string{},
+		},
+		{
+			name: "single element",
+			in:   []int{1},
+			want: []string{"1"},
+		},
+		{
+			name: "multiple elements",
+			in:   []int{1, 2, 3},
+			want: []string{"1", "2", "3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Map(tt.in, strconv.Itoa)
+			assertEq(t, tt.want, got)
+		})
+	}
+}
+
+func TestMapErr(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      []string
+		want    []int
+		wantErr string
+	}{
+		{
+			name: "nil",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "empty",
+			in:   []string{},
+			want: []int{},
+		},
+		{
+			name: "single element",
+			in:   []string{"1"},
+			want: []int{1},
+		},
+		{
+			name: "multiple elmeents",
+			in:   []string{"1", "2", "3"},
+			want: []int{1, 2, 3},
+		},
+		{
+			name:    "err",
+			in:      []string{"1", "2", "err", "3"},
+			wantErr: "index 2: strconv.Atoi",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MapErr(tt.in, strconv.Atoi)
+			assertErr(t, tt.wantErr, err)
+			assertEq(t, tt.want, got)
+		})
+	}
+}
+
+func TestMapCtx(t *testing.T) {
+	canceled := func() context.Context {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		return ctx
+	}()
+
+	ignoreCtx := func(_ context.Context, s string) (int, error) {
+		return strconv.Atoi(s)
+	}
+	respectCtx := func(ctx context.Context, s string) (int, error) {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		return ignoreCtx(ctx, s)
+	}
+
+	tests := []struct {
+		name    string
+		fn      []func(context.Context, string) (int, error)
+		ctx     []context.Context
+		in      []string
+		want    []int
+		wantErr string
+	}{
+		{
+			name: "nil",
+			fn:   arr(ignoreCtx, respectCtx),
+			ctx:  arr(context.Background(), canceled),
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "empty",
+			fn:   arr(ignoreCtx, respectCtx),
+			ctx:  arr(context.Background(), canceled),
+			in:   []string{},
+			want: []int{},
+		},
+		{
+			name: "non-empty",
+			fn:   arr(ignoreCtx, respectCtx),
+			ctx:  arr(context.Background()),
+			in:   []string{"1", "2", "3"},
+			want: []int{1, 2, 3},
+		},
+		{
+			name: "ignore context error",
+			fn:   arr(ignoreCtx),
+			ctx:  arr(context.Background(), canceled),
+			in:   []string{"1", "2", "3"},
+			want: []int{1, 2, 3},
+		},
+		{
+			name:    "context error",
+			fn:      arr(respectCtx),
+			ctx:     arr(canceled),
+			in:      []string{"1", "2", "3"},
+			wantErr: "index 0: " + context.Canceled.Error(),
+		},
+		{
+			name:    "fn error",
+			fn:      arr(ignoreCtx),
+			ctx:     arr(context.Background(), canceled),
+			in:      []string{"1", "err", "3"},
+			wantErr: "index 1: strconv.Atoi",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, fn := range tt.fn {
+				for _, ctx := range tt.ctx {
+					got, err := MapCtx(ctx, tt.in, fn)
+					assertErr(t, tt.wantErr, err)
+					assertEq(t, tt.want, got)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkMap(b *testing.B) {
+	xs := make([]int, 10000)
+	for b.Loop() {
+		Map(xs, func(x int) int {
+			return x
+		})
+	}
+}
+
+func assertEq(t testing.TB, want any, got any) {
+	t.Helper()
+
+	if reflect.DeepEqual(want, got) {
+		return
+	}
+
+	t.Fatalf(`assertEq failed, got:
+%+v
+-- want --
+%+v
+`, got, want)
+}
+
+func assertErr(t testing.TB, wantErr string, err error) {
+	t.Helper()
+
+	if wantErr == "" {
+		if err != nil {
+			t.Fatalf("assertErr failed, want no error, got:\n%v", err)
+		}
+		return
+	}
+
+	if err == nil {
+		t.Fatalf("assertErr failed, wanted error, got nil. wante:\n%v", wantErr)
+	}
+
+	if !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf(`assertErr failed, got unexpected error:
+%v
+-- want (contains) --
+%v
+`, err, wantErr)
+	}
+}
+
+func arr[T any](vs ...T) []T {
+	return vs
+}


### PR DESCRIPTION
This is an example of extending a stdlib package with functions that could be plausible to be part of slices.