### PR TITLE
shardval: Sharded value backed by sync.Pool

### DIFF
--- a/go.work
+++ b/go.work
@@ -3,6 +3,7 @@ go 1.24
 use (
 	.
 	./container/set
+	./sync/exp/shardval
 	./xstd/xslices
 	./xstd/xsync
 )

--- a/sync/exp/shardval/README.md
+++ b/sync/exp/shardval/README.md
@@ -1,0 +1,23 @@
+# shardval
+
+shardval provides an implementation of a sharded value backed by [sync.Pool](https://pkg.go.dev/sync#Pool).
+
+This is useful for performance-sensitive code that is running across many cores
+where contention can cause significant slowdowns.
+
+## Benchmarks
+
+Run on a Macbook Pro (M2 Pro).
+
+| CPUs                          | 1     | 2     | 4      | 8      | 12     |
+| ----------------------------- | ----- | ----- | ------ | ------ | ------ |
+| BenchmarkCounterLowBound      | 1.981 | 1.023 | 0.5134 | 0.2616 | 0.1906 |
+| BenchmarkCounterAtomic        | 3.77  | 13.39 | 22.49  | 35.95  | 70.24  |
+| BenchmarkCounterMutex         | 7.748 | 7.538 | 7.535  | 7.529  | 7.549  |
+| BenchmarkCounterSharded       | 10.32 | 5.263 | 3.056  | 1.362  | 1.652  |
+| BenchmarkCounterShardedAtomic | 12.87 | 6.655 | 4.828  | 3.57   | 2.296  |
+| BenchmarkCounterShardedMutex  | 18.42 | 9.366 | 5.209  | 2.449  | 2.722  |
+
+`BenchmarkCounterLowBound` sets a lower bound for the benchmark by incrementing a local integer.
+
+Atomics scale very poorly -- as the number of cores increase, we generally to see increased # of operations (and hence lower ns/op), yet atomics show an increase. So for example, going from 1 core to 2 core, the ns/op increases by 3.5x, but cores increased 2x, so we're spending 7x the total CPU time to do the same work.

--- a/sync/exp/shardval/benchmark_counter_test.go
+++ b/sync/exp/shardval/benchmark_counter_test.go
@@ -1,0 +1,86 @@
+package shardval
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func BenchmarkLoopSerial(b *testing.B) {
+	for range b.N { //nolint:revive // intentional empty block
+	}
+}
+
+func BenchmarkCounterLowBound(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		var i int
+		for pb.Next() {
+			i++
+		}
+		_ = i
+	})
+}
+
+func BenchmarkCounterAtomic(b *testing.B) {
+	var i atomic.Int64
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			i.Add(1)
+		}
+	})
+}
+
+func BenchmarkCounterMutex(b *testing.B) {
+	var mu sync.Mutex
+	var i int64
+	for b.Loop() {
+		mu.Lock()
+		i++
+		mu.Unlock()
+	}
+}
+
+func BenchmarkCounterSharded(b *testing.B) {
+	// Since there's no synchronization possible with `*int64`,
+	// `ForEach` cannot be called till the `With` calls are complete.
+	// This is useful when the results are not necessary till the work is complete.
+	var sharded Value[int64]
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			sharded.With(func(v *int64) {
+				*v++
+			})
+		}
+	})
+}
+
+func BenchmarkCounterShardedAtomic(b *testing.B) {
+	// Atomics allow concurrent use, so `ForAll` can be called concurrently to `With`.
+	var sharded Value[atomic.Int64]
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			sharded.With(func(v *atomic.Int64) {
+				v.Add(1)
+			})
+		}
+	})
+}
+
+func BenchmarkCounterShardedMutex(b *testing.B) {
+	// A mutex should be used in scenarios where `With` and `ForAll` need to be
+	// called concurrently, and atomics (or similar) aren't available.
+	type lockedInt struct {
+		mu sync.Mutex
+		v  int
+	}
+	var sharded Value[lockedInt]
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			sharded.With(func(v *lockedInt) {
+				v.mu.Lock()
+				defer v.mu.Unlock()
+				v.v++
+			})
+		}
+	})
+}

--- a/sync/exp/shardval/doc.go
+++ b/sync/exp/shardval/doc.go
@@ -1,0 +1,6 @@
+// Package shardval provides an implementation of a sharded value.
+//
+// This is useful for performance-sensitive code that is running across many cores
+// where contention can cause significant slowdowns.
+// See benchmarks for more details.
+package shardval

--- a/sync/exp/shardval/go.mod
+++ b/sync/exp/shardval/go.mod
@@ -1,0 +1,3 @@
+module go.prashantv.com/sync/exp/shardval
+
+go 1.24

--- a/sync/exp/shardval/shardval.go
+++ b/sync/exp/shardval/shardval.go
@@ -1,0 +1,109 @@
+package shardval
+
+import (
+	"runtime"
+	"sync"
+)
+
+// Value is a sharded value implemented using a [sync.Pool] for per-P locality.
+// It is used to represent a value that's sharded into many pieces
+// which are updated in `With`, and then assembled in `ForEach`.
+//
+// The number of shards should scale with O(GOMAXPROCS), though there is no hard limit.
+type Value[T any] struct {
+	pool sync.Pool
+
+	mu    sync.Mutex // below fields are protected by mu.
+	all   []*T
+	reuse []*shard[T] // GC'd elements, reused if the pool is empty.
+}
+
+// shard is an indirection used to detects elements dropped from the pool (via finalizers).
+type shard[T any] struct {
+	val *T
+}
+
+// With runs the given function with exclusive access to the shard.
+//
+// Many callers may call With concurrently.
+//
+// If called concurrently with [ForEach], the same value may be processed by both
+// functions so addititional synchronization within T is required.
+func (val *Value[T]) With(fn func(*T)) {
+	s := val.get()
+	defer val.pool.Put(s)
+
+	fn(s.val)
+}
+
+// ForEach iterates over all shards.
+//
+// If called concurretnly with [With], the same value may be processed by both functions
+// so addititional synchronization within T is required.
+func (val *Value[T]) ForEach(fn func(*T)) {
+	val.mu.Lock()
+	defer val.mu.Unlock()
+
+	for i := range val.all {
+		fn(val.all[i])
+	}
+}
+
+// Shards returns the number of shards.
+func (val *Value[T]) Shards() int {
+	val.mu.Lock()
+	defer val.mu.Unlock()
+
+	return len(val.all)
+}
+
+func (val *Value[T]) get() *shard[T] {
+	s, ok := val.pool.Get().(*shard[T])
+	if ok {
+		return s
+	}
+
+	val.mu.Lock()
+	defer val.mu.Unlock()
+
+	// The lock may take time, so check if there's a free shard again.
+	s, ok = val.pool.Get().(*shard[T])
+	if ok {
+		return s
+	}
+
+	if s, ok := val.reuseLocked(); ok {
+		return s
+	}
+
+	s = val.newLocked()
+	return s
+}
+
+func (val *Value[T]) reuseLocked() (*shard[T], bool) {
+	if len(val.reuse) == 0 {
+		return nil, false
+	}
+
+	s := val.reuse[0]
+	val.reuse[0] = nil
+	val.reuse = val.reuse[1:]
+	return s, true
+}
+
+func (val *Value[T]) newLocked() *shard[T] {
+	s := &shard[T]{
+		val: new(T),
+	}
+	val.all = append(val.all, s.val)
+	runtime.SetFinalizer(s, val.finalize)
+	return s
+}
+
+func (val *Value[T]) finalize(s *shard[T]) {
+	val.mu.Lock()
+	defer val.mu.Unlock()
+
+	val.reuse = append(val.reuse, s)
+	runtime.SetFinalizer(s, val.finalize)
+}

--- a/sync/exp/shardval/shardval_test.go
+++ b/sync/exp/shardval/shardval_test.go
@@ -1,0 +1,80 @@
+package shardval
+
+import (
+	"math/rand"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+func TestShardVal_With(t *testing.T) {
+	const goroutines = 123
+
+	var total int64
+	goIncrements := make([]int, goroutines)
+	for i := range goIncrements {
+		goIncrements[i] = rand.Intn(2000)
+		total += int64(goIncrements[i])
+	}
+
+	var sharded Value[int64]
+
+	var wg sync.WaitGroup
+	for _, increments := range goIncrements {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for range increments {
+				sharded.With(func(i *int64) {
+					*i++
+				})
+				runtime.GC()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	var count int64
+	sharded.ForEach(func(i *int64) {
+		count += *i
+	})
+	if count != total {
+		t.Fatalf("mismatch, want %v, got %v", total, count)
+	}
+
+	shards := sharded.Shards()
+	goMaxProcs := runtime.GOMAXPROCS(0)
+	t.Logf("%d shards with %d GOMAXPROCS, ratio = %.2f", shards, goMaxProcs, float64(shards)/float64(goMaxProcs))
+}
+
+func TestShardVal_With_Unique(t *testing.T) {
+	// Verify concurrent calls to With result in exclusive accesses to the shard.
+	const (
+		goroutines      = 100
+		perGoIncrements = 100
+	)
+
+	var sharded Value[sync.Mutex]
+
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for range perGoIncrements {
+				sharded.With(func(mu *sync.Mutex) {
+					if !mu.TryLock() {
+						t.Error("concurrent use of shard in With")
+					}
+					mu.Unlock()
+				})
+				runtime.GC()
+			}
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
Implement a sharded value backed by `sync.Pool` to take advantage
of its per-P local cache.